### PR TITLE
Fix wrong org name for APPUiO community

### DIFF
--- a/data-gathering/github_repos.json
+++ b/data-gathering/github_repos.json
@@ -40,7 +40,7 @@
 		"Communities": {
 			"name": "Communities, Projekte und Einzelfirmen",
 			"institutions":	[
-				{"name": "APPUiO","orgs": ["axa-ch"]},
+				{"name": "APPUiO","orgs": ["appuio"]},
 				{"name": "arillso","orgs": ["arillso"]},
 				{"name": "dat.alets.ch","orgs": ["Dataletsch"]},
 				{"name": "Hitobito","orgs": ["hitobito"]},

--- a/docs/notebooks/github_repos.json
+++ b/docs/notebooks/github_repos.json
@@ -40,7 +40,7 @@
 		"Communities": {
 			"name": "Communities, Projekte und Einzelfirmen",
 			"institutions":	[
-				{"name": "APPUiO","orgs": ["axa-ch"]},
+				{"name": "APPUiO","orgs": ["appuio"]},
 				{"name": "arillso","orgs": ["arillso"]},
 				{"name": "dat.alets.ch","orgs": ["Dataletsch"]},
 				{"name": "Hitobito","orgs": ["hitobito"]},


### PR DESCRIPTION
Looks like a copy-pasta issue. I don't think the colleagues over at APPUiO use the AXA organization. ;)