### PR TITLE
feat: add digris AG

### DIFF
--- a/data-gathering/github_repos.json
+++ b/data-gathering/github_repos.json
@@ -81,7 +81,8 @@
 			"institutions": [
 				{"name": "Radio Bern RaBe","orgs": ["radiorabe"]},
 				{"name": "Scout24 Schweiz AG","orgs": ["Scout24-CH"]},
-				{"name": "SWISS TXT AG","orgs": ["swisstxt"]}
+				{"name": "SWISS TXT AG","orgs": ["swisstxt"]},
+				{"name": "digris AG", "orgs": ["digris"]}
 			]
 		},
 		"Gov_Companies": {

--- a/docs/notebooks/github_repos.json
+++ b/docs/notebooks/github_repos.json
@@ -79,7 +79,8 @@
 			"institutions": [
 				{"name": "Radio Bern RaBe","orgs": ["radiorabe"]},
 				{"name": "Scout24 Schweiz AG","orgs": ["Scout24-CH"]},
-				{"name": "SWISS TXT AG","orgs": ["swisstxt"]}
+				{"name": "SWISS TXT AG","orgs": ["swisstxt"]},
+				{"name": "digris AG", "orgs": ["digris"]}
 			]
 		},
 		"Gov_Companies": {


### PR DESCRIPTION
digris AG is a swiss DAB+ broadcast provider that provides regional DAB+ services all over Switzerland.