### PR TITLE
feat: add EBU in new NGO category

### DIFF
--- a/data-gathering/github_repos.json
+++ b/data-gathering/github_repos.json
@@ -129,6 +129,12 @@
 				{"name": "Berner Fachhochschule","orgs": ["bfh","iam-ictm","bfh-science"]},
 				{"name": "Universität Bern","orgs": ["digital-sustainability","scg-unibe-ch","IAM-CGG","unibe-iap-mw","CMPG","reymond-group","ConsBiol-unibern","kogpsy","ubern-mia","zmk-unibe-ch","unibe-cns","UB-Bern","ub-unibe-ch","hpc-unibe-ch","id-unibe-ch","unibe-ch"]}
 			]
+		},
+		"NGOs": {
+			"name": "Nichtregierungsorganisationen",
+			"institutions": [
+				{"name": "European Broadcasting Union","orgs": ["ebu"]}
+			]
 		}
 	}
 }

--- a/docs/notebooks/github_repos.json
+++ b/docs/notebooks/github_repos.json
@@ -127,6 +127,12 @@
 				{"name": "Berner Fachhochschule","orgs": ["bfh","iam-ictm","bfh-science"]},
 				{"name": "Universität Bern","orgs": ["digital-sustainability","scg-unibe-ch","IAM-CGG","unibe-iap-mw","CMPG","reymond-group","ConsBiol-unibern","kogpsy","ubern-mia","zmk-unibe-ch","unibe-cns","UB-Bern","ub-unibe-ch","hpc-unibe-ch","id-unibe-ch","unibe-ch"]}
 			]
+		},
+		"NGOs": {
+			"name": "Nichtregierungsorganisationen",
+			"institutions": [
+				{"name": "European Broadcasting Union","orgs": ["ebu"]}
+			]
 		}
 	}
 }


### PR DESCRIPTION
Adds the European Broadcast Union in the new `NGOs` sector as recommended in https://github.com/digital-sustainability/oss-github-benchmark/issues/17#issuecomment-742485578.

Does this needed further changes to make the NGOs sector work or is it ok I I let you sort that out?

Fixes #17 