### PR TITLE
feat: add Digitec Galaxus AG

### DIFF
--- a/data-gathering/github_repos.json
+++ b/data-gathering/github_repos.json
@@ -82,9 +82,10 @@
 		"Others": {
 			"name": "Andere Unternehmenen",
 			"institutions": [
+				{"name": "Digitec Galaxus AG", "orgs": ["DigitecGalaxus"]},
+				{"name": "digris AG", "orgs": ["digris"]},
 				{"name": "Scout24 Schweiz AG","orgs": ["Scout24-CH"]},
-				{"name": "SWISS TXT AG","orgs": ["swisstxt"]},
-				{"name": "digris AG", "orgs": ["digris"]}
+				{"name": "SWISS TXT AG","orgs": ["swisstxt"]}
 			]
 		},
 		"Gov_Companies": {


### PR DESCRIPTION
I added them to "Others" since there is no "Retail" sector and Scout 24 seems the closes match wrt similar countries.

I also reordered the "Others" category so it's alphabetical while I was at it.