### PR TITLE
feat: add CERN

### DIFF
--- a/data-gathering/github_repos.json
+++ b/data-gathering/github_repos.json
@@ -129,6 +129,7 @@
 			"name": "Hochschulen und Forschung",
 			"institutions": [
 				{"name": "Berner Fachhochschule","orgs": ["bfh","iam-ictm","bfh-science"]},
+				{"name": "European Organization for Nuclear Research (CERN)","orgs": ["CERN", "cernopendata", "cern-fts", "cerndb", "cernops", "AliceO2Group", "cms-opendata-analyses", "cvmfs", "CERN-E-Ternity"]},
 				{"name": "Swiss National Supercomputing Center","orgs": ["eth-csc"]},
 				{"name": "Fondation Campus Biotech Geneva","orgs": ["fcbg-hnp"]},
 				{"name": "Universität Bern","orgs": ["digital-sustainability","scg-unibe-ch","IAM-CGG","unibe-iap-mw","CMPG","reymond-group","ConsBiol-unibern","kogpsy","ubern-mia","zmk-unibe-ch","unibe-cns","UB-Bern","ub-unibe-ch","hpc-unibe-ch","id-unibe-ch","unibe-ch"]}


### PR DESCRIPTION
This only scratches the surface of repos available from cern.

~I put it in NGOs because it is funded similar to EBU. Would you rather have it in ResearchAndEducation where it would fit just as well?~ Moved to ResearchAndEducation since I found a new orga I wanted to add, it makes more sense there anyway.