### PR TITLE
feat: add VeriSO

### DIFF
--- a/data-gathering/github_repos.json
+++ b/data-gathering/github_repos.json
@@ -63,7 +63,8 @@
 				{"name": "Opendigitalradio","orgs": ["Opendigitalradio"]},
 				{"name": "OpenOlitor","orgs": ["openolitor"]},
 				{"name": "School of Data in Switzerland","orgs": ["schoolofdata-ch"]},
-				{"name": "Open Source Challenge","orgs": ["opensource-challenge"]}
+				{"name": "Open Source Challenge","orgs": ["opensource-challenge"]},
+				{"name": "VeriSO","orgs": ["veriso"]}
 			]
 		},
 		"Insurances": {


### PR DESCRIPTION
To my understanding VeriSO (@veriso) is a collaboration between canton Solothurn and canton Berne. 

The orga isn't well documented but I found [an article on qgis.ch](https://www.qgis.ch/de/news/cadastre-artikel-ueber-verifikationsfachschale-veriso) that corroborates this.