### PR TITLE
feat: add Opendigitalradio

### DIFF
--- a/data-gathering/github_repos.json
+++ b/data-gathering/github_repos.json
@@ -49,6 +49,7 @@
 				{"name": "Caluma","orgs": ["projectcaluma"]},
 				{"name": "dat.alets.ch","orgs": ["Dataletsch"]},
 				{"name": "Hitobito","orgs": ["hitobito"]},
+				{"name": "Opendigitalradio","orgs": ["Opendigitalradio"]},
 				{"name": "OpenOlitor","orgs": ["openolitor"]},
 				{"name": "School of Data in Switzerland","orgs": ["schoolofdata-ch"]}
 			]


### PR DESCRIPTION
Opendigitalradio is a Geneva non-profit that builds digital radio broadcast tools. Their DAB+ toolchain powers the @digris DAB+ regions in Switzerland. As far as I understand they are somewhat close the community around the EBU and ITU (International Telecommunications Union) which are also both headquartered in Geneva.