### PR TITLE
feat(ci): configure linting for github_repos.json

### DIFF
--- a/.github/workflows/validate-input.yaml
+++ b/.github/workflows/validate-input.yaml
@@ -1,0 +1,20 @@
+name: Test input data
+
+on:
+  push:
+    paths:
+    - data-gathering/github_repos.json
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+        architecture: 'x64'
+    - name: lint data
+      run: |
+        python -mjson.tool data-gathering/github_repos.json


### PR DESCRIPTION
To ensure random citizen scientists like me don't bork the file ;)

Runs on push so it will also run on forks rather than only running on PRs.

I'd recommend also adding a job that validates the `orgs` but this covers the bare minimum needed to ensure that the schdule doesn't run into a JSON error