### PR TITLE
feat: add ICT-Berufsbildung

### DIFF
--- a/data-gathering/github_repos.json
+++ b/data-gathering/github_repos.json
@@ -1252,6 +1252,14 @@
                   "uzh",
                   "ZurichNLP"
                ]
+            },
+            {
+               "uuid":"9929b685-c0c1-4742-999c-91792bc0cd22",
+               "shortname":"ict-berufsbildung",
+               "name_de":"ICT-Berufsbildung",
+               "orgs":[
+                  "ICT-Berufsbildung"
+               ]
             }
          ]
       },


### PR DESCRIPTION
I think `ResearchAndEducation` is the best fit but will move it to something like NGOs if requested.