### PR TITLE
Fixed shortname/name_de of unprofessional

### DIFF
--- a/data-gathering/github_repos.json
+++ b/data-gathering/github_repos.json
@@ -461,8 +461,8 @@
             },
             {
                "uuid":"a9bce5be-1175-4faf-9589-298fea4cb7b6",
-               "shortname":"unprofession",
-               "name_de":"unprofession",
+               "shortname":"unprofessional",
+               "name_de":"unprofessional",
                "orgs":[
                   "unprofession-al"
                ]


### PR DESCRIPTION
unprofessional has a confusing org handle on github (adoption of the domain name `https://unprofession.al`) which has probably lead a mistake in the naming. This PR fixed this issue.