### PR TITLE
Add Open Circle AG company

### DIFF
--- a/github_repos.json
+++ b/github_repos.json
@@ -588,11 +588,15 @@
     "uuid": "66e054eb-a175-441c-91cd-1bb17217fda3",
     "sector": "IT",
     "ts": null,
-    "shortname": "itigo",
-    "name_de": "ITIGO AG",
+    "shortname": "occ",
+    "name_de": "Open Circle AG",
     "orgs": [
       {
         "name": "itigoag",
+        "ts": null
+      },
+      {
+        "name": "open-circle-ltd",
         "ts": null
       }
     ]


### PR DESCRIPTION
Renaming from ITIGO AG to Open Circle AG. Reason is the merger of the companies and add the open-circle-ltd Github organization.

Source: https://www.open-circle.ch/fusion-young-solutions-ag-mit-itigo-ag/