### PR TITLE
Add new OSS organisation «machinelearningZH»

### DIFF
--- a/github_repos.json
+++ b/github_repos.json
@@ -3304,6 +3304,10 @@
       {
         "name": "FNSKtZH",
         "ts": null
+      },
+      {
+        "name": "machinelearningZH",
+        "ts": null
       }
     ]
   },


### PR DESCRIPTION
The Canton of Zurich has created a new GitHub organisation named «machinelearningZH» to publish AI + ML code of PoCs and pilot projects.

https://github.com/machinelearningZH

Please be so kind and add this to your list of orgs. 

Thanks!